### PR TITLE
0.11 Closing file after mime-type checking

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -315,9 +315,12 @@ module CarrierWave
     end
 
     def mime_magic_content_type
-      MimeMagic.by_magic(File.open(path)).try(:type) if path
+      file = File.open(path)
+      MimeMagic.by_magic(file).try(:type) if path
     rescue Errno::ENOENT
       nil
+    ensure
+      file.close rescue nil
     end
 
     def mime_types_content_type

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -315,12 +315,11 @@ module CarrierWave
     end
 
     def mime_magic_content_type
-      file = File.open(path)
-      MimeMagic.by_magic(file).try(:type) if path
+      File.open(path) do |file|
+        MimeMagic.by_magic(file).try(:type) if path
+      end
     rescue Errno::ENOENT
       nil
-    ensure
-      file.close rescue nil
     end
 
     def mime_types_content_type


### PR DESCRIPTION
Hi!

I was getting `Errno::EACCES:  Permission denied @ sys_fail2 ...` after updating to `0.11.1 or .2` from `0.11.0` on Windows. The added mime-type checking did not close the opened file and Windows is - unfortunately - not happy about it.

I am using `move_to_cache` and `move_to_store` with `true` in my Rails app due to cleanup reasons. Copying the file does of course not cause the error.

Not sure if this is the right place for the issue or if the new mimemagic gem would be better. Regarding the method signature, it is the callers response to close the file though.

Regards,
j